### PR TITLE
Keeps current timer on click while running

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -85,7 +85,10 @@ document.addEventListener('keyup', (event) => {
 });
 
 timerDisplay.addEventListener('click', () => {
-  Elements.showTimerInput();
+  if (!Timer.isRunning()) {
+    Elements.showTimerInput();
+  }
+
   pauseTimer();
 });
 


### PR DESCRIPTION
Related issue: #17 

Allows edit the timer only when its stopped, if the user click on timer when its running, the timer will stop (but will keep the current value). 

Clicking on the play button will continue the timer, clicking on the timer allow configure a new time.

If the timer is stopped, the behavior is the same as before.